### PR TITLE
Improved the usefulness of mock failure output by including arrays and by differentiating between floats and integers

### DIFF
--- a/docs/CommonUtils.brs.html
+++ b/docs/CommonUtils.brs.html
@@ -28,15 +28,15 @@
 </nav>
 
 <div id="main">
-    
+
     <h1 class="page-title">CommonUtils.brs</h1>
-    
-
-    
 
 
 
-    
+
+
+
+
     <section>
         <article>
             <pre class="prettyprint source linenums"><code>' /**
@@ -336,23 +336,38 @@ function Rooibos_Common_asString(input) as string
         return input
     else if Rooibos_Common_isInteger(input) or Rooibos_Common_isLongInteger(input) or Rooibos_Common_isBoolean(input) then
         return input.ToStr()
-    else if Rooibos_Common_isFloat(input) or Rooibos_Common_isDouble(input) then
+    else if Rooibos_Common_isFloat(input) then
+        if Instr(1, Str(input), ".") = 0
+            return Str(input).Trim() + ".0"
+        end if
+        return Str(input).Trim()
+    else if Rooibos_Common_isDouble(input) then
         return Str(input).Trim()
     else if type(input) = "roSGNode" then
         return "Node(" + input.subType() + ")"
     else if type(input) = "roAssociativeArray" then
-        isFirst = true
         text = "{"
-        if (not isFirst) then
-            text = text + ","
-            isFirst = false
-        end if
-        for each key in input
-            if key &lt;> "__mocks" and key &lt;> "__stubs" then
-                text = text + key + ":" + Rooibos_Common_asString(input[key])
+        inputKeys = input.keys()
+        for i = 0 to inputKeys.count() - 1
+            key = inputKeys[i]
+            if key <> "__mocks" AND key <> "__stubs" then
+                text += key + ":" + Rooibos_Common_asString(input[key])
+                if i < inputKeys.count() - 1
+                    text += ", "
+                end if
             end if
         end for
-        text = text + "}"
+        text += "}"
+        return text
+    else if Rooibos_Common_isArray(input) then
+        text = "["
+        for i = 0 to input.count() - 1
+            text += Rooibos_Common_asString(input[i])
+            if i < input.count() - 1
+                text += ", "
+            end if
+        end for
+        text += "]"
         return text
     else if Rooibos_Common_isFunction(input) then
         return input.toStr()

--- a/src/source/CommonUtils.bs
+++ b/src/source/CommonUtils.bs
@@ -293,23 +293,38 @@ namespace Rooibos.Common
       return input
     else if Rooibos.Common.isInteger(input) or Rooibos.Common.isLongInteger(input) or Rooibos.Common.isBoolean(input)
       return input.ToStr()
-    else if Rooibos.Common.isFloat(input) or Rooibos.Common.isDouble(input)
+    else if Rooibos.Common.isFloat(input)
+      if Instr(1, Str(input), ".") = 0
+        return Str(input).Trim() + ".0"
+      end if
+      return Str(input).Trim()
+    else if Rooibos.Common.isDouble(input)
       return Str(input).Trim()
     else if type(input) = "roSGNode"
       return "Node(" + input.subType() + ")"
     else if type(input) = "roAssociativeArray"
-      isFirst = true
       text = "{"
-      if (not isFirst)
-        text = text + ","
-        isFirst = false
-      end if
-      for each key in input
-        if key <> "__mocks" and key <> "__stubs"
-          text = text + key + ":" + Rooibos.Common.asString(input[key])
+      inputKeys = input.keys()
+      for i = 0 to inputKeys.count() - 1
+        key = inputKeys[i]
+        if key <> "__mocks" AND key <> "__stubs"
+          text += key + ":" + Rooibos.Common.asString(input[key])
+          if i < inputKeys.count() - 1
+            text += ", "
+          end if
         end if
       end for
-      text = text + "}"
+      text += "}"
+      return text
+    else if Rooibos.Common.isArray(input)
+      text = "["
+      for i = 0 to input.count() - 1
+        text += Rooibos.Common.asString(input[i])
+        if i < input.count() - 1
+          text += ", "
+        end if
+      end for
+      text += "]"
       return text
     else if Rooibos.Common.isFunction(input)
       return input.toStr()


### PR DESCRIPTION
**Problem:**

The console output for a failed assert isn't as helpful as it could be. I had a particular issue today where the assert failed but the output of the expected object and the actual object were visually identical:

```
Error Message: mock failure on 'setFields' : on Invocation #0, expected arg #0 to be '{instantreplayskipincrement:10desiredcontrols:}' got '{instantreplayskipincrement:10desiredcontrols:}'
```

As well as not actually showing any differences that could have caused the assertion failure, there's an array in both of those objects that is missing. The lack of spaces between multiple keys and their values also makes it hard to read.

**Change:**

The reason for the failure that was established after investigation turned out to be that one of the `10` values was an integer and the other was a floating point. So this difference is now taken into account when generating the output.

I also added arrays to the output which for some reason weren't being taken into account at all.

And finally I added some spaces between the values to make it easier to read.

The new output for the above scenario is therefore:

```
Error Message: mock failure on 'setFields' : on Invocation #0, expected arg #0 to be '{desiredcontrols:[info, rewind, play, fastforward, replay], instantreplayskipincrement:10}' got '{desiredcontrols:[info, rewind, play, fastforward, replay], instantreplayskipincrement:10.0}')
```

This output immediately shows us what the problem is (`10` vs `10.0`) but would also have shown us what the problem was if the difference was in the arrays, which previously it would not have done.